### PR TITLE
Bugfix: "Mhz" -> "MHz"

### DIFF
--- a/ha_services/__init__.py
+++ b/ha_services/__init__.py
@@ -3,5 +3,5 @@
     Helpers to send periodic information via MQTT to Home Assistant
 """
 
-__version__ = '2.6.0'
+__version__ = '2.6.1'
 __author__ = 'Jens Diemer <github@jensdiemer.de>'

--- a/ha_services/mqtt4homeassistant/system_info/cpu.py
+++ b/ha_services/mqtt4homeassistant/system_info/cpu.py
@@ -12,7 +12,7 @@ class CpuFreqSensor(Sensor):
         kwargs.setdefault('uid', 'cpu_freq')
         kwargs.setdefault('device_class', 'frequency')
         kwargs.setdefault('state_class', 'measurement')
-        kwargs.setdefault('unit_of_measurement', 'Mhz')
+        kwargs.setdefault('unit_of_measurement', 'MHz')
         kwargs.setdefault('suggested_display_precision', 0)
         super().__init__(**kwargs)
 

--- a/ha_services/mqtt4homeassistant/tests/test_integration_main_sub_1.snapshot.json
+++ b/ha_services/mqtt4homeassistant/tests/test_integration_main_sub_1.snapshot.json
@@ -24,7 +24,7 @@
         "topic": "homeassistant/sensor/main_uid/main_uid-process_start/state"
     },
     {
-        "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"frequency\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-cpu_freq/attributes\", \"name\": \"CPU frequency\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-cpu_freq/state\", \"suggested_display_precision\": 0, \"unique_id\": \"main_uid-cpu_freq\", \"unit_of_measurement\": \"Mhz\"}",
+        "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"frequency\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-cpu_freq/attributes\", \"name\": \"CPU frequency\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-cpu_freq/state\", \"suggested_display_precision\": 0, \"unique_id\": \"main_uid-cpu_freq\", \"unit_of_measurement\": \"MHz\"}",
         "topic": "homeassistant/sensor/main_uid/main_uid-cpu_freq/config"
     },
     {


### PR DESCRIPTION
"""
...is using native unit of measurement 'Mhz' which is not a valid unit for the device class ('frequency') it is using; expected one of ['kHz', 'Hz', 'MHz', 'GHz']; """