### PR TITLE
Add and send "qos" and "retain"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ New usage, see: `ha_services/example.py`
 
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
-* [**dev**](https://github.com/jedie/ha-services/compare/v2.10.0...main)
+* [v2.11.0](https://github.com/jedie/ha-services/compare/v2.10.0...v2.11.0)
+  * 2025-06-17 - Add and send "qos" and "retain"
   * 2025-06-16 - Update requirements
 * [v2.10.0](https://github.com/jedie/ha-services/compare/v2.9.0...v2.10.0)
   * 2025-04-08 - Optional validation of sensor states

--- a/ha_services/__init__.py
+++ b/ha_services/__init__.py
@@ -4,5 +4,5 @@
 """
 
 # See https://packaging.python.org/en/latest/specifications/version-specifiers/
-__version__ = '2.10.0'
+__version__ = '2.11.0'
 __author__ = 'Jens Diemer <github@jensdiemer.de>'

--- a/ha_services/mqtt4homeassistant/data_classes.py
+++ b/ha_services/mqtt4homeassistant/data_classes.py
@@ -39,6 +39,8 @@ class ComponentState:
 class ComponentConfig:
     topic: str
     payload: dict
+    qos: int = 0
+    retain: bool = True  # retain by default, so Home Assistant can discover the component
 
 
 @dataclasses.dataclass

--- a/ha_services/mqtt4homeassistant/system_info/tests/test_netstat.py
+++ b/ha_services/mqtt4homeassistant/system_info/tests/test_netstat.py
@@ -49,10 +49,30 @@ class NetStatSensorsTestCase(TestCase):
             self.assertEqual(
                 mqtt_client_mock.get_state_messages(),
                 [
-                    {'payload': 0.1201171875, 'topic': 'homeassistant/sensor/bar/bar-eth0sent/state'},
-                    {'payload': 0.0, 'topic': 'homeassistant/sensor/bar/bar-eth0sentrate/state'},
-                    {'payload': 0.4453125, 'topic': 'homeassistant/sensor/bar/bar-eth0received/state'},
-                    {'payload': 0.0, 'topic': 'homeassistant/sensor/bar/bar-eth0receivedrate/state'},
+                    {
+                        'topic': 'homeassistant/sensor/bar/bar-eth0sent/state',
+                        'payload': 0.1201171875,
+                        'qos': 0,
+                        'retain': False,
+                    },
+                    {
+                        'topic': 'homeassistant/sensor/bar/bar-eth0sentrate/state',
+                        'payload': 0.0,
+                        'qos': 0,
+                        'retain': False,
+                    },
+                    {
+                        'topic': 'homeassistant/sensor/bar/bar-eth0received/state',
+                        'payload': 0.4453125,
+                        'qos': 0,
+                        'retain': False,
+                    },
+                    {
+                        'topic': 'homeassistant/sensor/bar/bar-eth0receivedrate/state',
+                        'payload': 0.0,
+                        'qos': 0,
+                        'retain': False,
+                    },
                 ],
             )
 
@@ -84,6 +104,11 @@ class NetStatSensorsTestCase(TestCase):
             # Check sample:
             self.assertEqual(
                 state_messages[0],
-                {'topic': 'homeassistant/sensor/bar/bar-eth0sent/state', 'payload': 0.1201171875},
+                {
+                    'topic': 'homeassistant/sensor/bar/bar-eth0sent/state',
+                    'payload': 0.1201171875,
+                    'qos': 0,
+                    'retain': False,
+                },
             )
             assert_snapshot(got=state_messages)

--- a/ha_services/mqtt4homeassistant/system_info/tests/test_netstat_happy_path_2.snapshot.json
+++ b/ha_services/mqtt4homeassistant/system_info/tests/test_netstat_happy_path_2.snapshot.json
@@ -1,18 +1,26 @@
 [
     {
         "payload": 0.1201171875,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/bar/bar-eth0sent/state"
     },
     {
         "payload": 0.0,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/bar/bar-eth0sentrate/state"
     },
     {
         "payload": 0.4453125,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/bar/bar-eth0received/state"
     },
     {
         "payload": 0.0,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/bar/bar-eth0receivedrate/state"
     }
 ]

--- a/ha_services/mqtt4homeassistant/system_info/tests/test_wifi_info_happy_path_1.snapshot.json
+++ b/ha_services/mqtt4homeassistant/system_info/tests/test_wifi_info_happy_path_1.snapshot.json
@@ -1,50 +1,74 @@
 [
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-wifi_device_name/attributes\", \"name\": \"Wifi Device Name\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-wifi_device_name/state\", \"unique_id\": \"main_uid-wifi_device_name\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-wifi_device_name/config"
     },
     {
         "payload": "wlo1",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-wifi_device_name/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-ESSID/attributes\", \"name\": \"Essid\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-ESSID/state\", \"unique_id\": \"main_uid-ESSID\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-ESSID/config"
     },
     {
         "payload": "foobar",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-ESSID/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-bit_rate/attributes\", \"name\": \"Bit rate\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-bit_rate/state\", \"unique_id\": \"main_uid-bit_rate\", \"unit_of_measurement\": \"Mb/s\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-bit_rate/config"
     },
     {
         "payload": 29.2,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-bit_rate/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-frequency/attributes\", \"name\": \"Frequency\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-frequency/state\", \"unique_id\": \"main_uid-frequency\", \"unit_of_measurement\": \"GHz\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-frequency/config"
     },
     {
         "payload": 5.18,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-frequency/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-link_quality/attributes\", \"name\": \"Link quality\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-link_quality/state\", \"unique_id\": \"main_uid-link_quality\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-link_quality/config"
     },
     {
         "payload": "45/70",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-link_quality/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-signal_level/attributes\", \"name\": \"Signal level\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-signal_level/state\", \"unique_id\": \"main_uid-signal_level\", \"unit_of_measurement\": \"dBm\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-signal_level/config"
     },
     {
         "payload": -65,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-signal_level/state"
     }
 ]

--- a/ha_services/mqtt4homeassistant/tests/test_integration_main_sub_1.snapshot.json
+++ b/ha_services/mqtt4homeassistant/tests/test_integration_main_sub_1.snapshot.json
@@ -1,162 +1,242 @@
 [
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-hostname/attributes\", \"name\": \"Hostname\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-hostname/state\", \"unique_id\": \"main_uid-hostname\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-hostname/config"
     },
     {
         "payload": "TheHostName",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-hostname/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"timestamp\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-up_time/attributes\", \"name\": \"System Up Time\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-up_time/state\", \"unique_id\": \"main_uid-up_time\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-up_time/config"
     },
     {
         "payload": "2009-02-13T23:<mocked-ticks>",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-up_time/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"timestamp\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-process_start/attributes\", \"name\": \"Process Start\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-process_start/state\", \"unique_id\": \"main_uid-process_start\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-process_start/config"
     },
     {
         "payload": "2009-02-13T23:31:30+00:00",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-process_start/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"frequency\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-cpu_freq/attributes\", \"name\": \"CPU frequency\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-cpu_freq/state\", \"suggested_display_precision\": 0, \"unique_id\": \"main_uid-cpu_freq\", \"unit_of_measurement\": \"MHz\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-cpu_freq/config"
     },
     {
         "payload": 1234,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-cpu_freq/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-swap_usage/attributes\", \"name\": \"Swap usage\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-swap_usage/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-swap_usage\", \"unit_of_measurement\": \"%\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-swap_usage/config"
     },
     {
         "payload": 123,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-swap_usage/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-system_load_1min/attributes\", \"name\": \"System load 1min.\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-system_load_1min/state\", \"suggested_display_precision\": 2, \"unique_id\": \"main_uid-system_load_1min\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-system_load_1min/config"
     },
     {
         "payload": 1,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-system_load_1min/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-total_cpu_usage/attributes\", \"name\": \"Total CPU usage\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-total_cpu_usage/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-total_cpu_usage\", \"unit_of_measurement\": \"%\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-total_cpu_usage/config"
     },
     {
         "payload": 12,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-total_cpu_usage/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-process_cpu_usage/attributes\", \"name\": \"Process CPU usage\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-process_cpu_usage/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-process_cpu_usage\", \"unit_of_measurement\": \"%\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-process_cpu_usage/config"
     },
     {
         "payload": 12,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-process_cpu_usage/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"temperature\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-temperaturecoretemp/attributes\", \"name\": \"Temperature coretemp\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-temperaturecoretemp/state\", \"suggested_display_precision\": 0, \"unique_id\": \"main_uid-temperaturecoretemp\", \"unit_of_measurement\": \"°C\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-temperaturecoretemp/config"
     },
     {
         "payload": 51.0,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-temperaturecoretemp/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"temperature\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-temperaturenvme/attributes\", \"name\": \"Temperature nvme\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-temperaturenvme/state\", \"suggested_display_precision\": 0, \"unique_id\": \"main_uid-temperaturenvme\", \"unit_of_measurement\": \"°C\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-temperaturenvme/config"
     },
     {
         "payload": 32.85,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-temperaturenvme/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"data_size\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0sent/attributes\", \"name\": \"eth0 sent\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0sent/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-eth0sent\", \"unit_of_measurement\": \"KiB\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0sent/config"
     },
     {
         "payload": "<mocked eth0 values>",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0sent/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"data_rate\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0sentrate/attributes\", \"name\": \"eth0 sent rate\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0sentrate/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-eth0sentrate\", \"unit_of_measurement\": \"KiB/s\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0sentrate/config"
     },
     {
         "payload": "<mocked eth0 values>",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0sentrate/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"data_size\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0received/attributes\", \"name\": \"eth0 received\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0received/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-eth0received\", \"unit_of_measurement\": \"KiB\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0received/config"
     },
     {
         "payload": "<mocked eth0 values>",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0received/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": \"data_rate\", \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0receivedrate/attributes\", \"name\": \"eth0 received rate\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-eth0receivedrate/state\", \"suggested_display_precision\": 1, \"unique_id\": \"main_uid-eth0receivedrate\", \"unit_of_measurement\": \"KiB/s\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0receivedrate/config"
     },
     {
         "payload": "<mocked eth0 values>",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-eth0receivedrate/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-wifi_device_name/attributes\", \"name\": \"Wifi Device Name\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-wifi_device_name/state\", \"unique_id\": \"main_uid-wifi_device_name\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-wifi_device_name/config"
     },
     {
         "payload": "wlo1",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-wifi_device_name/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-ESSID/attributes\", \"name\": \"Essid\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-ESSID/state\", \"unique_id\": \"main_uid-ESSID\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-ESSID/config"
     },
     {
         "payload": "foobar",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-ESSID/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-bit_rate/attributes\", \"name\": \"Bit rate\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-bit_rate/state\", \"unique_id\": \"main_uid-bit_rate\", \"unit_of_measurement\": \"Mb/s\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-bit_rate/config"
     },
     {
         "payload": 29.2,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-bit_rate/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-frequency/attributes\", \"name\": \"Frequency\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-frequency/state\", \"unique_id\": \"main_uid-frequency\", \"unit_of_measurement\": \"GHz\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-frequency/config"
     },
     {
         "payload": 5.18,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-frequency/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-link_quality/attributes\", \"name\": \"Link quality\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": null, \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-link_quality/state\", \"unique_id\": \"main_uid-link_quality\", \"unit_of_measurement\": null}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-link_quality/config"
     },
     {
         "payload": "45/70",
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-link_quality/state"
     },
     {
         "payload": "{\"component\": \"sensor\", \"device\": {\"identifiers\": \"main_uid\", \"name\": \"Main Device\"}, \"device_class\": null, \"json_attributes_topic\": \"homeassistant/sensor/main_uid/main_uid-signal_level/attributes\", \"name\": \"Signal level\", \"origin\": {\"name\": \"ha-services-tests\", \"support_url\": \"https://pypi.org/project/ha_services/\", \"sw_version\": \"1.2.3\"}, \"state_class\": \"measurement\", \"state_topic\": \"homeassistant/sensor/main_uid/main_uid-signal_level/state\", \"unique_id\": \"main_uid-signal_level\", \"unit_of_measurement\": \"dBm\"}",
+        "qos": 0,
+        "retain": true,
         "topic": "homeassistant/sensor/main_uid/main_uid-signal_level/config"
     },
     {
         "payload": -65,
+        "qos": 0,
+        "retain": false,
         "topic": "homeassistant/sensor/main_uid/main_uid-signal_level/state"
     }
 ]

--- a/ha_services/tests/__init__.py
+++ b/ha_services/tests/__init__.py
@@ -17,7 +17,7 @@ def pre_configure_tests() -> None:
 
     # Hacky way to display more "assert"-Context in failing tests:
     _MIN_MAX_DIFF = unittest.util._MAX_LENGTH - unittest.util._MIN_DIFF_LEN
-    unittest.util._MAX_LENGTH = int(os.environ.get('UNITTEST_MAX_LENGTH', 300))
+    unittest.util._MAX_LENGTH = int(os.environ.get('UNITTEST_MAX_LENGTH', 1000))
     unittest.util._MIN_DIFF_LEN = unittest.util._MAX_LENGTH - _MIN_MAX_DIFF
 
     # Deny any request via docket/urllib3 because tests they should mock all requests:


### PR DESCRIPTION
Use `qos=0, retain=False` as default for any sensor message and `qos=0, retain=True` as default for config message.